### PR TITLE
Handle large floats

### DIFF
--- a/json.c
+++ b/json.c
@@ -318,7 +318,7 @@ bool json_write_bool(json_t *json, const char *label, bool val)
 }
 
 static
-bool json__write_number(json_t *json, const char *label, char str[64], int len, int max)
+bool json__write_number(json_t *json, const char *label, const char *str, int len, int max)
 {
 	assert(len < max); /* If this is ever hit, the library needs a larger buffer  */
 	return len > 0


### PR DESCRIPTION
Use exponent form for (de)serialization of numbers, which 1) is required by the JSON spec, 2) can store data much more densely for large numbers (and improves some non-exponent-range numbers too), and 3) guarantees round-trip floating point equality according to the spec.